### PR TITLE
0.59 & 1.21.8 support

### DIFF
--- a/common/src/main/java/net/momirealms/sparrow/heart/SparrowHeart.java
+++ b/common/src/main/java/net/momirealms/sparrow/heart/SparrowHeart.java
@@ -44,7 +44,7 @@ public abstract class SparrowHeart {
             String bukkitVersion = Bukkit.getServer().getBukkitVersion().split("-")[0];
             String packageName;
             switch (bukkitVersion) {
-                case "1.21.6", "1.21.7" -> packageName = "reobf_1_21_r5";
+                case "1.21.6", "1.21.7", "1.21.8" -> packageName = "reobf_1_21_r5";
                 case "1.21.5" -> packageName = "reobf_1_21_r4";
                 case "1.21.4" -> packageName = "reobf_1_21_r3";
                 case "1.21.2", "1.21.3" -> packageName = "reobf_1_21_r2";

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion = 0.58
+projectVersion = 0.59
 projectGroup=net.momirealms
 
 #systemProp.socks.proxyHost=127.0.0.1


### PR DESCRIPTION
This pull request includes a version update and compatibility enhancement for the `SparrowHeart` module. The most important changes are:

### Compatibility Updates:
* [`common/src/main/java/net/momirealms/sparrow/heart/SparrowHeart.java`](diffhunk://#diff-3293ebb6c6d1219321228f15a5ff3ba819e29e62773e4aa170906427d7162e82L47-R47): Added support for Bukkit version `1.21.8` by mapping it to the existing `reobf_1_21_r5` package.

### Versioning:
* [`gradle.properties`](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19L1-R1): Updated the project version from `0.58` to `0.59`.